### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Nuxt Snackbar provides a wrapper for [vue3-snackbar](https://github.com/craigril
 
     ```bash
     # Using pnpm
-    pnpm add -D nuxt-snackbar
+    npx nuxi@latest module add snackbar
 
     # Using yarn
-    yarn add -D nuxt-snackbar
+    npx nuxi@latest module add snackbar
 
     # Using npm
-    npm install --save-dev nuxt-snackbar
+    npx nuxi@latest module add snackbar
     ```
 
 2. Add `nuxt-snackbar` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ Nuxt Snackbar provides a wrapper for [vue3-snackbar](https://github.com/craigril
 1. Add `nuxt-snackbar` dependency to your project
 
     ```bash
-    # Using pnpm
-    npx nuxi@latest module add snackbar
-
-    # Using yarn
-    npx nuxi@latest module add snackbar
-
-    # Using npm
     npx nuxi@latest module add snackbar
     ```
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
